### PR TITLE
To add until date

### DIFF
--- a/lib/helpers/index.js
+++ b/lib/helpers/index.js
@@ -67,6 +67,9 @@ var helpers = function () {
         }
         if (event.recurring.byMonth) {
           recur = recur + ";BYMONTH=" + event.recurring.byMonth;
+        }        
+        if (event.recurring.until) {
+          recur = recur + ";UNTIL=" + event.recurring.until;
         }
 
         return recur.toUpperCase();


### PR DESCRIPTION
To add until date for the recurring events because in outlook it requires end date. for example if we create recurring event from zoom they will give option either choose event end by end_date or by occurrence. in our project we have end date only by occurrence. please add this also i made change in react-add-to-calendar-recurring.min.js file for RRULE setup.